### PR TITLE
Allow transaction date-times to be specified explicitly as well.

### DIFF
--- a/src/Form/TupasForm.php
+++ b/src/Form/TupasForm.php
@@ -206,7 +206,7 @@ class TupasForm implements TupasFormInterface
      */
     public function getStamp()
     {
-        return sprintf('%s%s', ($this->dateTime)->format('YmdHis'), $this->getTransactionId());
+        return sprintf('%s%s', $this->dateTime->format('YmdHis'), $this->getTransactionId());
     }
 
     /**

--- a/src/Form/TupasForm.php
+++ b/src/Form/TupasForm.php
@@ -11,6 +11,13 @@ class TupasForm implements TupasFormInterface
     use TupasEncryptionTrait;
 
     /**
+     * The transaction date-time.
+     *
+     * @var \DateTime
+     */
+    protected $dateTime;
+
+    /**
      * The transaction id.
      *
      * @var string
@@ -60,15 +67,17 @@ class TupasForm implements TupasFormInterface
     protected $bank;
 
     /**
-     * TupasForm constructor.
+     * Constructs a new instance.
      *
      * @param BankInterface $bank
      *   The bank.
+     * @param \DateTime $dateTime
+     *   The transaction date-time or NULL to use the current date-time.
      */
-    public function __construct(BankInterface $bank, $defaultLanguage = 'en')
+    public function __construct(BankInterface $bank, \DateTime $dateTime = null)
     {
         $this->bank = $bank;
-        $this->setLanguage($defaultLanguage);
+        $this->dateTime = $dateTime ?: new \DateTime();
     }
 
     /**
@@ -197,7 +206,7 @@ class TupasForm implements TupasFormInterface
      */
     public function getStamp()
     {
-        return sprintf('%s%s', (new \DateTime())->format('YmdHis'), $this->getTransactionId());
+        return sprintf('%s%s', ($this->dateTime)->format('YmdHis'), $this->getTransactionId());
     }
 
     /**

--- a/src/Form/TupasForm.php
+++ b/src/Form/TupasForm.php
@@ -71,12 +71,15 @@ class TupasForm implements TupasFormInterface
      *
      * @param BankInterface $bank
      *   The bank.
+     * @param string $defaultLanguage
+     *   The ISO-639 1 code of the default user interface language.
      * @param \DateTime $dateTime
      *   The transaction date-time or NULL to use the current date-time.
      */
-    public function __construct(BankInterface $bank, \DateTime $dateTime = null)
+    public function __construct(BankInterface $bank, $defaultLanguage = 'en', \DateTime $dateTime = null)
     {
         $this->bank = $bank;
+        $this->setLanguage($defaultLanguage);
         $this->dateTime = $dateTime ?: new \DateTime();
     }
 

--- a/tests/TupasFormTest.php
+++ b/tests/TupasFormTest.php
@@ -117,13 +117,30 @@ class TupasFormTest extends \PHPUnit_Framework_TestCase
      * Tests stamp generation.
      *
      * @covers ::getStamp
-     * @covers ::getTransactionId
+     *
+     * @depends testTransaction
      */
-    public function testGetStamp()
+    public function testGetStampWithDefinedDateTimeAndTransactionId()
+    {
+        $dateTime = (new \DateTime())->setTimestamp(0);
+        $transactionId = 314159;
+        $sut = new TupasForm($this->bank, $dateTime);
+        $sut->setTransactionId($transactionId);
+        $stamp = $sut->getStamp();
+        $this->assertSame('19700101000000314159', $stamp);
+    }
+
+    /**
+     * Tests stamp generation.
+     *
+     * @covers ::getStamp
+     *
+     * @depends testTransaction
+     */
+    public function testGetStampWithUndefinedDateTimeAndTransactionId()
     {
         $sut = new TupasForm($this->bank);
         $response = $sut->getStamp();
-        $this->assertEquals(substr($response, 0, 14), (new \DateTime())->format('YmdHis'));
         $this->assertEquals(substr($response, -6), $sut->getTransactionId());
     }
 

--- a/tests/TupasFormTest.php
+++ b/tests/TupasFormTest.php
@@ -124,7 +124,7 @@ class TupasFormTest extends \PHPUnit_Framework_TestCase
     {
         $dateTime = (new \DateTime())->setTimestamp(0);
         $transactionId = 314159;
-        $sut = new TupasForm($this->bank, $dateTime);
+        $sut = new TupasForm($this->bank, 'en', $dateTime);
         $sut->setTransactionId($transactionId);
         $stamp = $sut->getStamp();
         $this->assertSame('19700101000000314159', $stamp);


### PR DESCRIPTION
This is directly useful for testing. That's exactly why I removed that one line from the existing test, as it uses runtime date-time generation which is a test smell, and subject to random failures.