### PR TITLE
Make transaction ID validation more strict, and take a wider range of valid values.

### DIFF
--- a/src/Form/TupasForm.php
+++ b/src/Form/TupasForm.php
@@ -209,7 +209,9 @@ class TupasForm implements TupasFormInterface
      */
     public function getStamp()
     {
-        return sprintf('%s%s', $this->dateTime->format('YmdHis'), $this->getTransactionId());
+        $transactionId = (string)$this->getTransactionId();
+        $transactionId = str_repeat('0', 6 - strlen($transactionId)) . $transactionId;
+        return sprintf('%s%s', $this->dateTime->format('YmdHis'), $transactionId);
     }
 
     /**

--- a/src/Tupas.php
+++ b/src/Tupas.php
@@ -108,20 +108,24 @@ class Tupas
     /**
      * Validates transaction id.
      *
-     * @param int $transaction_id
+     * @param int $referenceTransactionId
      *   The transaction id.
      *
      * @return bool
      *   True if valid, false if not valid.
      */
-    public function isValidTransaction($transaction_id)
+    public function isValidTransaction($referenceTransactionId)
     {
-        // Stamp cannot be empty.
-        if (!$value = $this->get('B02K_STAMP')) {
+        if (!is_int($referenceTransactionId) or $referenceTransactionId < 0 or $referenceTransactionId > 999999) {
             return false;
         }
-        $timestamp = substr($value, -6);
-
-        return $transaction_id == $timestamp;
+        // Stamp cannot be empty.
+        if (!$stamp = $this->get('B02K_STAMP')) {
+            return false;
+        }
+        $receivedTransActionId = substr($stamp, -6);
+        $referenceTransactionId = (string)$referenceTransactionId;
+        $referenceTransactionId = str_repeat('0', 6 - strlen($referenceTransactionId)) . $referenceTransactionId;
+        return $referenceTransactionId === $receivedTransActionId;
     }
 }

--- a/tests/TupasFormTest.php
+++ b/tests/TupasFormTest.php
@@ -123,11 +123,11 @@ class TupasFormTest extends \PHPUnit_Framework_TestCase
     public function testGetStampWithDefinedDateTimeAndTransactionId()
     {
         $dateTime = (new \DateTime())->setTimestamp(0);
-        $transactionId = 314159;
+        $transactionId = 314;
         $sut = new TupasForm($this->bank, 'en', $dateTime);
         $sut->setTransactionId($transactionId);
         $stamp = $sut->getStamp();
-        $this->assertSame('19700101000000314159', $stamp);
+        $this->assertSame('19700101000000000314', $stamp);
     }
 
     /**

--- a/tests/TupasTest.php
+++ b/tests/TupasTest.php
@@ -146,7 +146,7 @@ class TupasTest extends \PHPUnit_Framework_TestCase
                     'B02K_CUSTID' => 123,
                     'B02K_CUSTTYPE' => 123,
                 ],
-                '123456',
+                123456,
                 '01',
             ],
             [
@@ -162,7 +162,7 @@ class TupasTest extends \PHPUnit_Framework_TestCase
                     'B02K_CUSTID' => 123,
                     'B02K_CUSTTYPE' => 123,
                 ],
-                '123456',
+                123456,
                 '02',
             ],
             [
@@ -178,7 +178,7 @@ class TupasTest extends \PHPUnit_Framework_TestCase
                     'B02K_CUSTID' => 123,
                     'B02K_CUSTTYPE' => 123,
                 ],
-                '123456',
+                123456,
                 '03',
             ],
             [
@@ -196,9 +196,26 @@ class TupasTest extends \PHPUnit_Framework_TestCase
                     'B02K_USRID' => 123,
                     'B02K_USERNAME' => 'username',
                 ],
-                '123456',
+                123456,
                 '03',
             ],
+        ];
+    }
+
+    /**
+     * Provides data to self::testIsValidTransaction().
+     */
+    public function provideIsValidTransaction()
+    {
+        return [
+            // Transaction IDs must be integers.
+            [true, '20161212232323123456', 123456],
+            [true, '20161212232323000456', 456],
+            // Transaction IDs must be identical, as loose comparisons can cause security breaches.
+            [false, 0, '0'],
+            [false, 0, false],
+            [false, 0, null],
+            [false, 0, '0x'],
         ];
     }
 
@@ -207,13 +224,23 @@ class TupasTest extends \PHPUnit_Framework_TestCase
      *
      * @covers ::isValidTransaction
      * @covers ::get
+     *
+     * @dataProvider provideIsValidTransaction
      */
-    public function testIsValidTransaction()
+    public function testIsValidTransaction($expected, $stamp, $reference_transaction_id)
+    {
+        $sut = new Tupas($this->bank, ['B02K_STAMP' => $stamp]);
+        $this->assertSame($expected, $sut->isValidTransaction($reference_transaction_id), sprintf('With B02K_STAMP %s and reference transaction ID %s.', var_export($stamp, true), var_export($reference_transaction_id, true)));
+    }
+
+    /**
+     * Tests isValidTransaction() method.
+     *
+     * @covers ::isValidTransaction
+     */
+    public function testIsValidTransactionShouldFailWithoutStamp()
     {
         $sut = new Tupas($this->bank, []);
-        $this->assertFalse($sut->isValidTransaction('123456'));
-        $sut = new Tupas($this->bank, ['B02K_STAMP' => '20161212232323123456']);
-        $this->assertTrue($sut->isValidTransaction('123456'));
-        $this->assertFalse($sut->isValidTransaction('1234567'));
+        $this->assertFalse($sut->isValidTransaction(123456));
     }
 }

--- a/tests/TupasTest.php
+++ b/tests/TupasTest.php
@@ -211,11 +211,10 @@ class TupasTest extends \PHPUnit_Framework_TestCase
             // Transaction IDs must be integers.
             [true, '20161212232323123456', 123456],
             [true, '20161212232323000456', 456],
-            // Transaction IDs must be identical, as loose comparisons can cause security breaches.
-            [false, 0, '0'],
-            [false, 0, false],
-            [false, 0, null],
-            [false, 0, '0x'],
+            // Transaction IDs must be identical, as loose comparisons can cause security breaches. For PHP 5 support,
+            // test with non-integers.
+            [false, '20161212232323000456', '456'],
+            [false, '20161212232323000456', 456.0],
         ];
     }
 


### PR DESCRIPTION
This reverts part of https://github.com/tuutti/php-tupas/commit/696296098b34eb0be85cba385be301f86dd04dd4, and adds more test coverage in order to ensure transaction IDs are exactly identical. It also adds 0-padding for transaction IDs when converted to strings, so integer IDs from other systems can be fed into this API without having to worry about the padding, which is internal.