### PR TITLE
Convert transaction IDs to strings, and loosen the validation up until what TUPAS allows.

### DIFF
--- a/src/Form/TupasForm.php
+++ b/src/Form/TupasForm.php
@@ -186,10 +186,11 @@ class TupasForm implements TupasFormInterface
     /**
      * {@inheritdoc}
      */
-    public function setTransactionId($transaction_id)
+    public function setTransactionId($transactionId)
     {
-        Assert::integer($transaction_id);
-        $this->transactionId = $transaction_id;
+        Assert::string($transactionId);
+        Assert::length($transactionId, 6);
+        $this->transactionId = $transactionId;
         return $this;
     }
 
@@ -199,7 +200,9 @@ class TupasForm implements TupasFormInterface
     public function getTransactionId()
     {
         if (!$this->transactionId) {
-            $this->transactionId = random_int(100000, 999999);
+            $transactionId = (string)random_int(0, 999999);
+            $transactionId = str_repeat('0', 6 - strlen($transactionId)) . $transactionId;
+            $this->setTransactionId($transactionId);
         }
         return $this->transactionId;
     }

--- a/src/Form/TupasFormInterface.php
+++ b/src/Form/TupasFormInterface.php
@@ -68,25 +68,25 @@ interface TupasFormInterface
     public function getReturnUrl();
 
     /**
-     * Sets the transaction id.
+     * Sets the transaction ID.
      *
-     * @param int $transaction_id
-     *   The transaction id.
+     * @param string $transactionId
+     *   The transaction ID.
      *
      * @return $this
      */
-    public function setTransactionId($transaction_id);
+    public function setTransactionId($transactionId);
 
     /**
-     * Gets the transaction id.
+     * Gets the transaction ID.
      *
      * This is used to make request unique and to validate
      * returning customer.
      *
-     * By default this is a random integer between 100000 and 999999.
+     * By default this is a random zero-padded number between 0 and 999999.
      *
-     * @return int
-     *   The transaction id.
+     * @return string
+     *   The transaction ID.
      */
     public function getTransactionId();
 

--- a/src/Tupas.php
+++ b/src/Tupas.php
@@ -5,6 +5,7 @@ namespace Tupas;
 use Tupas\Entity\BankInterface;
 use Tupas\Exception\HashMatchException;
 use Tupas\Exception\TupasGenericException;
+use Webmozart\Assert\Assert;
 
 /**
  * Class Tupas.
@@ -108,7 +109,7 @@ class Tupas
     /**
      * Validates transaction id.
      *
-     * @param int $referenceTransactionId
+     * @param string $referenceTransactionId
      *   The transaction id.
      *
      * @return bool
@@ -116,16 +117,15 @@ class Tupas
      */
     public function isValidTransaction($referenceTransactionId)
     {
-        if (!is_int($referenceTransactionId) or $referenceTransactionId < 0 or $referenceTransactionId > 999999) {
-            return false;
-        }
+        Assert::string($referenceTransactionId);
+        Assert::length($referenceTransactionId, 6);
+
         // Stamp cannot be empty.
         if (!$stamp = $this->get('B02K_STAMP')) {
             return false;
         }
-        $receivedTransActionId = substr($stamp, -6);
-        $referenceTransactionId = (string)$referenceTransactionId;
-        $referenceTransactionId = str_repeat('0', 6 - strlen($referenceTransactionId)) . $referenceTransactionId;
-        return $referenceTransactionId === $receivedTransActionId;
+
+        $receivedTransactionId = substr($stamp, -6);
+        return $referenceTransactionId === $receivedTransactionId;
     }
 }

--- a/tests/TupasFormTest.php
+++ b/tests/TupasFormTest.php
@@ -109,8 +109,8 @@ class TupasFormTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($response);
         $this->assertEquals($sut->getTransactionId(), $response);
 
-        $sut->setTransactionId(123456);
-        $this->assertEquals($sut->getTransactionId(), 123456);
+        $sut->setTransactionId('123456');
+        $this->assertEquals($sut->getTransactionId(), '123456');
     }
 
     /**
@@ -123,11 +123,11 @@ class TupasFormTest extends \PHPUnit_Framework_TestCase
     public function testGetStampWithDefinedDateTimeAndTransactionId()
     {
         $dateTime = (new \DateTime())->setTimestamp(0);
-        $transactionId = 314;
+        $transactionId = '314159';
         $sut = new TupasForm($this->bank, 'en', $dateTime);
         $sut->setTransactionId($transactionId);
         $stamp = $sut->getStamp();
-        $this->assertSame('19700101000000000314', $stamp);
+        $this->assertSame('19700101000000314159', $stamp);
     }
 
     /**

--- a/tests/TupasTest.php
+++ b/tests/TupasTest.php
@@ -146,7 +146,7 @@ class TupasTest extends \PHPUnit_Framework_TestCase
                     'B02K_CUSTID' => 123,
                     'B02K_CUSTTYPE' => 123,
                 ],
-                123456,
+                '123456',
                 '01',
             ],
             [
@@ -162,7 +162,7 @@ class TupasTest extends \PHPUnit_Framework_TestCase
                     'B02K_CUSTID' => 123,
                     'B02K_CUSTTYPE' => 123,
                 ],
-                123456,
+                '123456',
                 '02',
             ],
             [
@@ -178,7 +178,7 @@ class TupasTest extends \PHPUnit_Framework_TestCase
                     'B02K_CUSTID' => 123,
                     'B02K_CUSTTYPE' => 123,
                 ],
-                123456,
+                '123456',
                 '03',
             ],
             [
@@ -196,7 +196,7 @@ class TupasTest extends \PHPUnit_Framework_TestCase
                     'B02K_USRID' => 123,
                     'B02K_USERNAME' => 'username',
                 ],
-                123456,
+                '123456',
                 '03',
             ],
         ];
@@ -208,13 +208,8 @@ class TupasTest extends \PHPUnit_Framework_TestCase
     public function provideIsValidTransaction()
     {
         return [
-            // Transaction IDs must be integers.
-            [true, '20161212232323123456', 123456],
-            [true, '20161212232323000456', 456],
-            // Transaction IDs must be identical, as loose comparisons can cause security breaches. For PHP 5 support,
-            // test with non-integers.
-            [false, '20161212232323000456', '456'],
-            [false, '20161212232323000456', 456.0],
+            [true, '20161212232323123456', '123456'],
+            [false, '20161212232323123456', '314159'],
         ];
     }
 
@@ -240,6 +235,6 @@ class TupasTest extends \PHPUnit_Framework_TestCase
     public function testIsValidTransactionShouldFailWithoutStamp()
     {
         $sut = new Tupas($this->bank, []);
-        $this->assertFalse($sut->isValidTransaction(123456));
+        $this->assertFalse($sut->isValidTransaction('123456'));
     }
 }


### PR DESCRIPTION
This takes the good parts of https://github.com/tuutti/php-tupas/pull/7, but loosens the strict validation somewhat, because I realized TUPAS allows more types of transaction IDs than just integers.